### PR TITLE
PHR-6374 ability to null out config keys in testing

### DIFF
--- a/config/src/main/java/com/pkb/common/config/MutableRawConfigStorage.java
+++ b/config/src/main/java/com/pkb/common/config/MutableRawConfigStorage.java
@@ -48,18 +48,16 @@ public final class MutableRawConfigStorage extends AbstractBaseConfigStorage {
     }
 
     private String getOverriddenOrOriginalValue(String key, Supplier<String> originalSupplier) {
-        String overriddenValue = overrideMap.get(key);
-        if (overriddenValue != null) {
-            return overriddenValue;
+        if (overrideMap.containsKey(key)) {
+            return overrideMap.get(key);
         }
         return originalSupplier.get();
     }
 
     @Override
     protected <P> Either<ConfigurationException, P> readValue(String key, Class<P> expectedType, Parser<P> parser) {
-        String overriddenValue = overrideMap.get(key);
-        if (overriddenValue != null) {
-            return parseValue(key, overriddenValue, expectedType, parser).orElse(() -> parseValue(key, configStorage.getString(key), expectedType, parser));
+        if (overrideMap.containsKey(key)) {
+            return parseValue(key, overrideMap.get(key), expectedType, parser).orElse(() -> parseValue(key, configStorage.getString(key), expectedType, parser));
         }
         return parseValue(key, configStorage.getString(key), expectedType, parser);
     }

--- a/config/src/test/java/com/pkb/common/config/MutableRawConfigStorageTest.java
+++ b/config/src/test/java/com/pkb/common/config/MutableRawConfigStorageTest.java
@@ -72,11 +72,11 @@ class MutableRawConfigStorageTest {
         assertEquals("overridden value", underTest.getString("notExistingKey", "default value"));
     }
 
-    @DisplayName("get string returns original value with override set to null")
+    @DisplayName("get string returns null value with override set to null")
     @Test
     public void getString7() {
         underTest.setValue("stringKey", null);
-        assertEquals("string value", underTest.getString("stringKey"));
+        assertEquals(null, underTest.getString("stringKey"));
     }
 
     @DisplayName("get string returns original value after override is reset")


### PR DESCRIPTION
currently, setting a null override is to represent that the original value is returned; this could be represented as not setting the override or, setting the override to the original value; I’d like to preserve setting an override to null to get back that null when asking for the key