### PR TITLE
changed distribution tag repository id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
 
     <distributionManagement>
         <repository>
-            <id>github-central</id>
+            <id>pkb-common</id>
             <name>pkb-common Packages</name>
             <url>https://maven.pkg.github.com/patientsknowbest/pkb-common</url>
         </repository>
         <snapshotRepository>
-            <id>github-snapshots</id>
+            <id>pkb-common</id>
             <name>pkb-common Packages</name>
             <url>https://maven.pkg.github.com/patientsknowbest/pkb-common</url>
         </snapshotRepository>


### PR DESCRIPTION
The repositories declared inside the DistributionManagement tag in the main POM have an id that must match the maven settings.xml file.

I have refactored the main settings.xml file so that we can use snapshots, therefore I need to change the id used.

TC config that will be used afterwards successfully builds: https://ci.pkb.io/buildConfiguration/PkbCommon_UnitTestsTestNewDistributionTag?mode=builds#all-projects