### PR TITLE
PHR-7033 Move Pulsar config to BaseConfig

### DIFF
--- a/config/src/main/java/com/pkb/common/config/AbstractBaseConfig.java
+++ b/config/src/main/java/com/pkb/common/config/AbstractBaseConfig.java
@@ -68,4 +68,24 @@ public abstract class AbstractBaseConfig implements BaseConfig {
     public boolean isFakeDateTimeServiceEnabled() {
         return storage.getBoolean("fakedatetimeservice.enabled", false);
     }
+
+    @Override
+    public String getPulsarServiceURL() {
+        return storage.getString("pulsarServiceURL", "pulsar://pulsar:6650");
+    }
+
+    @Override
+    public String getPulsarDefaultNamespce() {
+        return storage.getString("pulsarDefaultNamespce", "defaultNS");
+    }
+
+    @Override
+    public boolean isPulsarServiceRegistrationEnabled() {
+        return storage.getBoolean("pulsarServiceRegistrationEnabled", false);
+    }
+
+    @Override
+    public boolean isPulsarTestSupportServicesEnabled() {
+        return storage.getBoolean("pulsarTestSupportServicesEnabled", false);
+    }
 }

--- a/config/src/main/java/com/pkb/common/config/BaseConfig.java
+++ b/config/src/main/java/com/pkb/common/config/BaseConfig.java
@@ -3,4 +3,8 @@ package com.pkb.common.config;
 public interface BaseConfig {
     String getBaseURL();
     boolean isFakeDateTimeServiceEnabled();
+    String getPulsarServiceURL();
+    String getPulsarDefaultNamespce();
+    boolean isPulsarServiceRegistrationEnabled();
+    boolean isPulsarTestSupportServicesEnabled();
 }


### PR DESCRIPTION
Move Pulsar config to BaseConfig, as all services need to have this config for testsupport