### PR TITLE
ConfigStorage backed by Spring Environment NEST-1

### DIFF
--- a/config/src/main/java/com/pkb/common/config/ConfigStorage.java
+++ b/config/src/main/java/com/pkb/common/config/ConfigStorage.java
@@ -2,6 +2,8 @@ package com.pkb.common.config;
 
 public interface ConfigStorage {
 
+    String MUTABLE_CONFIG_KEY = "mutableConfig.enabled";
+
     Boolean getBoolean(String key);
 
     Boolean getBoolean(String key, Boolean defaultValue);
@@ -26,5 +28,5 @@ public interface ConfigStorage {
 
     void reset();
 
-    ConfigStorage getImmutableConfig();
+    ImmutableConfigStorage getImmutableConfig();
 }

--- a/config/src/main/java/com/pkb/common/config/ConfigStorageFactory.java
+++ b/config/src/main/java/com/pkb/common/config/ConfigStorageFactory.java
@@ -6,10 +6,14 @@ public final class ConfigStorageFactory {
     }
 
     public static ConfigStorage getConfigStorage() {
-        ImmutableRawConfigStorage immutableRawConfigStorage = ImmutableRawConfigStorage.createDefault();
-        if (immutableRawConfigStorage.isMutableConfigEnabled()) {
-            return new MutableRawConfigStorage(immutableRawConfigStorage);
+        return getConfigStorage(ImmutableRawConfigStorage.createDefault());
+    }
+
+
+    public static ConfigStorage getConfigStorage(ImmutableConfigStorage baseStorage) {
+        if (baseStorage.isMutableConfigEnabled()) {
+            return new MutableRawConfigStorage(baseStorage);
         }
-        return immutableRawConfigStorage;
+        return baseStorage;
     }
 }

--- a/config/src/main/java/com/pkb/common/config/ImmutableConfigStorage.java
+++ b/config/src/main/java/com/pkb/common/config/ImmutableConfigStorage.java
@@ -1,0 +1,30 @@
+package com.pkb.common.config;
+
+public interface ImmutableConfigStorage extends ConfigStorage {
+
+    @Override
+    default ImmutableConfigStorage getImmutableConfig() {
+        return this;
+    }
+
+    @Override
+    default boolean isMutableConfigEnabled() {
+        return getBoolean(MUTABLE_CONFIG_KEY, false);
+    }
+
+    @Override
+    default void setValue(String key, String value) {
+        /* no-op */
+    }
+
+    @Override
+    default OverrideRemovalResult removeOverrideAtKey(String key) {
+        return OverrideRemovalResult.NO_OP_AS_CONFIG_IS_IMMUTABLE;
+    }
+
+    @Override
+    default void reset() {
+        /* no-op */
+    }
+
+}

--- a/config/src/main/java/com/pkb/common/config/ImmutableRawConfigStorage.java
+++ b/config/src/main/java/com/pkb/common/config/ImmutableRawConfigStorage.java
@@ -1,14 +1,12 @@
 package com.pkb.common.config;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.unmodifiableMap;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import io.vavr.control.Either;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
 
-public final class ImmutableRawConfigStorage extends AbstractBaseConfigStorage {
+public final class ImmutableRawConfigStorage extends AbstractBaseConfigStorage implements ImmutableConfigStorage {
 
     public static final ImmutableRawConfigStorage EMPTY = new ImmutableRawConfigStorage(emptyMap());
 
@@ -16,7 +14,7 @@ public final class ImmutableRawConfigStorage extends AbstractBaseConfigStorage {
         return LayeredLoader.defaultLoader().load();
     }
 
-    public static ImmutableRawConfigStorage merge(ImmutableRawConfigStorage original, ImmutableRawConfigStorage overrides) {
+    static ImmutableRawConfigStorage merge(ImmutableRawConfigStorage original, ImmutableRawConfigStorage overrides) {
         Map<String, String> mergedStorage = new HashMap<>(original.storage);
         mergedStorage.putAll(overrides.storage);
         return new ImmutableRawConfigStorage(unmodifiableMap(mergedStorage));
@@ -29,11 +27,6 @@ public final class ImmutableRawConfigStorage extends AbstractBaseConfigStorage {
     }
 
     @Override
-    protected <P> Either<ConfigurationException, P> readValue(String key, Class<P> expectedType, Parser<P> parser) {
-        return parseValue(key, storage.get(key), expectedType, parser);
-    }
-
-    @Override
     public String getString(String key) {
         return storage.get(key);
     }
@@ -43,28 +36,4 @@ public final class ImmutableRawConfigStorage extends AbstractBaseConfigStorage {
         return storage.getOrDefault(key, defaultValue);
     }
 
-    @Override
-    public boolean isMutableConfigEnabled() {
-        return getBoolean(MUTABLE_CONFIG_KEY, false);
-    }
-
-    @Override
-    public void setValue(String key, String value) {
-        /* no-op */
-    }
-
-    @Override
-    public OverrideRemovalResult removeOverrideAtKey(String key) {
-        return OverrideRemovalResult.NO_OP_AS_CONFIG_IS_IMMUTABLE;
-    }
-
-    @Override
-    public void reset() {
-        /* no-op */
-    }
-
-    @Override
-    public ConfigStorage getImmutableConfig() {
-        return this;
-    }
 }

--- a/config/src/main/java/com/pkb/common/config/MutableConfigStorage.java
+++ b/config/src/main/java/com/pkb/common/config/MutableConfigStorage.java
@@ -1,0 +1,10 @@
+package com.pkb.common.config;
+
+public interface MutableConfigStorage extends ConfigStorage {
+
+    @Override
+    default boolean isMutableConfigEnabled() {
+        return true;
+    }
+
+}

--- a/config/src/main/java/com/pkb/common/config/MutableRawConfigStorage.java
+++ b/config/src/main/java/com/pkb/common/config/MutableRawConfigStorage.java
@@ -4,14 +4,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import io.vavr.control.Either;
-
-public final class MutableRawConfigStorage extends AbstractBaseConfigStorage {
+public final class MutableRawConfigStorage extends AbstractBaseConfigStorage implements MutableConfigStorage {
 
     private final Map<String, String> overrideMap = new HashMap<>();
-    private final ImmutableRawConfigStorage configStorage;
+    private final ImmutableConfigStorage configStorage;
 
-    MutableRawConfigStorage(ImmutableRawConfigStorage configStorage) {
+    MutableRawConfigStorage(ImmutableConfigStorage configStorage) {
         this.configStorage = configStorage;
     }
 
@@ -23,11 +21,6 @@ public final class MutableRawConfigStorage extends AbstractBaseConfigStorage {
     @Override
     public String getString(String key, String defaultValue) {
         return getOverriddenOrOriginalValue(key, () -> configStorage.getString(key, defaultValue));
-    }
-
-    @Override
-    public boolean isMutableConfigEnabled() {
-        return true;
     }
 
     @Override
@@ -53,7 +46,7 @@ public final class MutableRawConfigStorage extends AbstractBaseConfigStorage {
     }
 
     @Override
-    public ConfigStorage getImmutableConfig() {
+    public ImmutableConfigStorage getImmutableConfig() {
         return configStorage;
     }
 
@@ -62,17 +55,5 @@ public final class MutableRawConfigStorage extends AbstractBaseConfigStorage {
             return overrideMap.get(key);
         }
         return originalSupplier.get();
-    }
-
-    @Override
-    protected <P> Either<ConfigurationException, P> readValue(String key, Class<P> expectedType, Parser<P> parser) {
-        if (overrideMap.containsKey(key)) {
-            String value = overrideMap.get(key);
-            if(value == null) {
-                return Either.right(null);
-            }
-            return parseValue(key, overrideMap.get(key), expectedType, parser).orElse(() -> parseValue(key, configStorage.getString(key), expectedType, parser));
-        }
-        return parseValue(key, configStorage.getString(key), expectedType, parser);
     }
 }

--- a/config/src/test/java/com/pkb/common/config/84fe55/41de19-approved.json
+++ b/config/src/test/java/com/pkb/common/config/84fe55/41de19-approved.json
@@ -1,0 +1,8 @@
+/*com.pkb.common.config.MutableRawConfigStorageTest.getInt7*/
+{
+  "0x1": {
+    "detailMessage": "missing configuration key: [intKey]",
+    "stackTrace": [],
+    "suppressedExceptions": []
+  }
+}

--- a/config/src/test/java/com/pkb/common/config/84fe55/521ac7-approved.json
+++ b/config/src/test/java/com/pkb/common/config/84fe55/521ac7-approved.json
@@ -1,0 +1,8 @@
+/*com.pkb.common.config.MutableRawConfigStorageTest.getBoolean7*/
+{
+  "0x1": {
+    "detailMessage": "missing configuration key: [booleanKey]",
+    "stackTrace": [],
+    "suppressedExceptions": []
+  }
+}

--- a/config/src/test/java/com/pkb/common/config/84fe55/7ff2dc-approved.json
+++ b/config/src/test/java/com/pkb/common/config/84fe55/7ff2dc-approved.json
@@ -1,0 +1,8 @@
+/*com.pkb.common.config.MutableRawConfigStorageTest.getInt9*/
+{
+  "0x1": {
+    "detailMessage": "malformed value\u003d[not an integer] for configuration key\u003d[intKey] (expected type\u003d[Integer])",
+    "stackTrace": [],
+    "suppressedExceptions": []
+  }
+}

--- a/config/src/test/java/com/pkb/common/config/84fe55/a42bd3-approved.json
+++ b/config/src/test/java/com/pkb/common/config/84fe55/a42bd3-approved.json
@@ -1,7 +1,7 @@
 /*com.pkb.common.config.MutableRawConfigStorageTest.getBoolean11*/
 {
   "0x1": {
-    "detailMessage": "malformed value\u003d[string value] for configuration key\u003d[stringKey] (expected type\u003d[Boolean])",
+    "detailMessage": "malformed value\u003d[not a boolean] for configuration key\u003d[stringKey] (expected type\u003d[Boolean])",
     "stackTrace": [],
     "suppressedExceptions": []
   }

--- a/config/src/test/java/com/pkb/common/config/84fe55/b44a6f-approved.json
+++ b/config/src/test/java/com/pkb/common/config/84fe55/b44a6f-approved.json
@@ -1,7 +1,7 @@
 /*com.pkb.common.config.MutableRawConfigStorageTest.getInt10*/
 {
   "0x1": {
-    "detailMessage": "malformed value\u003d[string value] for configuration key\u003d[stringKey] (expected type\u003d[Integer])",
+    "detailMessage": "malformed value\u003d[not an integer] for configuration key\u003d[stringKey] (expected type\u003d[Integer])",
     "stackTrace": [],
     "suppressedExceptions": []
   }

--- a/config/src/test/java/com/pkb/common/config/84fe55/ca6b38-approved.json
+++ b/config/src/test/java/com/pkb/common/config/84fe55/ca6b38-approved.json
@@ -1,0 +1,8 @@
+/*com.pkb.common.config.MutableRawConfigStorageTest.getBoolean9*/
+{
+  "0x1": {
+    "detailMessage": "malformed value\u003d[not a boolean] for configuration key\u003d[booleanKey] (expected type\u003d[Boolean])",
+    "stackTrace": [],
+    "suppressedExceptions": []
+  }
+}

--- a/config/src/test/java/com/pkb/common/config/84fe55/e9f610-approved.json
+++ b/config/src/test/java/com/pkb/common/config/84fe55/e9f610-approved.json
@@ -1,7 +1,7 @@
 /*com.pkb.common.config.MutableRawConfigStorageTest.getBoolean10*/
 {
   "0x1": {
-    "detailMessage": "malformed value\u003d[string value] for configuration key\u003d[stringKey] (expected type\u003d[Boolean])",
+    "detailMessage": "malformed value\u003d[not a boolean] for configuration key\u003d[stringKey] (expected type\u003d[Boolean])",
     "stackTrace": [],
     "suppressedExceptions": []
   }

--- a/config/src/test/java/com/pkb/common/config/MutableRawConfigStorageTest.java
+++ b/config/src/test/java/com/pkb/common/config/MutableRawConfigStorageTest.java
@@ -132,11 +132,11 @@ class MutableRawConfigStorageTest {
         assertEquals(false, underTest.getBoolean("notExistingKey", true));
     }
 
-    @DisplayName("getBoolean returns null value with override set to null")
+    @DisplayName("getBoolean throws exception with override set to null")
     @Test
     public void getBoolean7() {
         underTest.setValue("booleanKey", null);
-        assertEquals(null, underTest.getBoolean("booleanKey"));
+        assertThrows(sameJsonAsApproved(), () -> underTest.getBoolean("booleanKey"));
     }
 
     @DisplayName("getBoolean throw exception when original value is not Boolean")
@@ -146,11 +146,11 @@ class MutableRawConfigStorageTest {
         assertThrows(sameJsonAsApproved(), () -> underTest.getBoolean("stringKey"));
     }
 
-    @DisplayName("getBoolean returns original value when overridden value is not Boolean")
+    @DisplayName("getBoolean throws exception when overridden value is not Boolean")
     @Test
     public void getBoolean9() {
         underTest.setValue("booleanKey", "not a boolean");
-        assertEquals(true, underTest.getBoolean("booleanKey"));
+        assertThrows(sameJsonAsApproved(), () -> underTest.getBoolean("booleanKey"));
     }
 
     @DisplayName("getBoolean throw exception when overridden value and original value are not Boolean values")
@@ -241,11 +241,11 @@ class MutableRawConfigStorageTest {
         assertEquals(6, underTest.getInt("notExistingKey", 7));
     }
 
-    @DisplayName("getInt returns null value with override set to null")
+    @DisplayName("getInt throws exception with override set to null")
     @Test
     public void getInt7() {
         underTest.setValue("intKey", null);
-        assertEquals(null, underTest.getInt("intKey"));
+        assertThrows(sameJsonAsApproved(), () -> underTest.getInt("intKey"));
     }
 
     @DisplayName("getInt throw exception when original value is not Integer")
@@ -255,11 +255,11 @@ class MutableRawConfigStorageTest {
         assertThrows(sameJsonAsApproved(), () -> underTest.getInt("stringKey"));
     }
 
-    @DisplayName("getInt returns original value when overridden value is not Integer")
+    @DisplayName("getInt throws exception when overridden value is not Integer")
     @Test
     public void getInt9() {
         underTest.setValue("intKey", "not an integer");
-        assertEquals(2, underTest.getInt("intKey"));
+        assertThrows(sameJsonAsApproved(), () -> underTest.getInt("intKey"));
     }
 
     @DisplayName("getInt throw exception when overridden value and original value are not Integers values")

--- a/spring-infrastructure/src/main/java/com/pkb/common/config/SpringConfigStorage.java
+++ b/spring-infrastructure/src/main/java/com/pkb/common/config/SpringConfigStorage.java
@@ -1,0 +1,26 @@
+package com.pkb.common.config;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.env.Environment;
+
+public class SpringConfigStorage extends AbstractBaseConfigStorage implements ImmutableConfigStorage {
+
+
+    private final Environment environment;
+
+    public SpringConfigStorage(@NotNull Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public String getString(String key) {
+        return environment.getProperty(key);
+    }
+
+    @Override
+    public String getString(String key, String defaultValue) {
+        return environment.getProperty(key, defaultValue);
+    }
+
+
+}


### PR DESCRIPTION
To make it easier to use the PKB Config classes in Spring Boot applications, I have added an immutable implementation of ConfigStorage that is backed by the Spring Environment rather than our own LayeredLoader. As part of doing this, I have refactored the ConfigStorage implementations somewhat to move more behaviour into the base classes, and introduced interfaces for Mutable/Immutable storages so that we can have multiple implementations.

One consequence of this is that I have changed some core behaviour of MutableConfigStorage to be more consistent with the other implementations. In particular, if you override a configuration key with a null value, it will now behave as the Immutable version would do - i.e. throw a MissingValueException; similarly, if you override a key with a value that won't parse as a particular type, requesting it as that type will result in an exception rather than silently falling back to the original, immutable value. This allowed for significantly cleaner implementation and results in a clearer, more consistent interface. As yet I have found no instances in our current test suite that break as a result of this change; the methods that accept a fallback default value already know how to catch the MissingValueException and return the default, so they are unaffected.