### PR TITLE
Add PingMessage definition (PNX-137)

### DIFF
--- a/pubsub/src/main/avro/PingMessage.avsc
+++ b/pubsub/src/main/avro/PingMessage.avsc
@@ -1,0 +1,9 @@
+{
+  "namespace": "com.pkb.common.pubsub.payload",
+  "type": "record",
+  "name": "PingMessage",
+  "fields": [
+    {"name": "content", "type": "string"}
+  ]
+
+}


### PR DESCRIPTION
Simple avro definition for ping messages used in pubsub for communicating between phoenix and phr