### PR TITLE
Restart camel routes between changing namespaces

### DIFF
--- a/test-control/src/main/java/com/pkb/common/testcontrol/camel/route/AbstractTestControlCamelRouteBuilder.java
+++ b/test-control/src/main/java/com/pkb/common/testcontrol/camel/route/AbstractTestControlCamelRouteBuilder.java
@@ -22,6 +22,7 @@ import java.net.URL;
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
 public abstract class AbstractTestControlCamelRouteBuilder extends RouteBuilder {
+    public static final String ROUTE_PROPERTY_IS_TEST_CONTROL = "io.pkb.route.property.istestcontrol";
     /**
      * Encapsulates the app-specific config required for these routes
      */
@@ -46,6 +47,7 @@ public abstract class AbstractTestControlCamelRouteBuilder extends RouteBuilder 
                 // Maybe replace this with a proper service discovery system later.
                 from("timer:startup?repeatCount=1")
                         .routeId("startupMessage")
+                        .routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString())
                         .setBody(constant(ImmutableStartup.builder()
                                 .name(config().getApplicationName())
                                 .callback(config().getApplicationTestControlCallbackURL())
@@ -58,14 +60,14 @@ public abstract class AbstractTestControlCamelRouteBuilder extends RouteBuilder 
             
             // Routes for test control requests
             rest()
-                    .put("setNamespace").route().bean(this, "setNamespace").endRest()
-                    .put("setFixedTimestamp").route().bean(this, "setFixedTimestamp").endRest()
-                    .put("moveTime").route().bean(this, "moveTime").endRest()
-                    .put("injectConfig").route().bean(this, "injectConfig").endRest()
-                    .put("clearInternalState").route().bean(this, "clearInternalState").endRest()
-                    .put("clearStorage").route().bean(this, "clearStorage").endRest()
-                    .put("logTestName").route().bean(this, "logTestName").endRest()
-                    .put("toggleDetailedLogging").route().bean(this, "toggleDetailedLogging").endRest();
+                    .put("setNamespace").route().routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString()).bean(this, "setNamespace").endRest()
+                    .put("setFixedTimestamp").route().routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString()).bean(this, "setFixedTimestamp").endRest()
+                    .put("moveTime").route().routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString()).bean(this, "moveTime").endRest()
+                    .put("injectConfig").route().routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString()).bean(this, "injectConfig").endRest()
+                    .put("clearInternalState").route().routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString()).bean(this, "clearInternalState").endRest()
+                    .put("clearStorage").route().routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString()).bean(this, "clearStorage").endRest()
+                    .put("logTestName").route().routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString()).bean(this, "logTestName").endRest()
+                    .put("toggleDetailedLogging").route().routeProperty(ROUTE_PROPERTY_IS_TEST_CONTROL, Boolean.TRUE.toString()).bean(this, "toggleDetailedLogging").endRest();
         }
     }
     

--- a/test-control/src/main/java/com/pkb/common/testcontrol/services/DefaultPubSubNamespaceService.java
+++ b/test-control/src/main/java/com/pkb/common/testcontrol/services/DefaultPubSubNamespaceService.java
@@ -1,12 +1,52 @@
 package com.pkb.common.testcontrol.services;
 
-public class DefaultPubSubNamespaceService implements PubSubNamespaceService {
+import com.pkb.common.testcontrol.camel.route.AbstractTestControlCamelRouteBuilder;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Route;
+import org.apache.camel.impl.engine.AbstractCamelContext;
+import org.apache.camel.spi.RouteStartupOrder;
+import org.apache.camel.util.function.ThrowingConsumer;
 
+import java.util.Comparator;
+
+public class DefaultPubSubNamespaceService implements PubSubNamespaceService {
+    private final CamelContext context;
+    
     private String currentNamespace = "defaultNS";
+
+    public DefaultPubSubNamespaceService(CamelContext context) {
+        this.context = context;
+    }
 
     @Override
     public void setCurrentNamespace(String currentNamespace) {
+        // We want to ensure that all _currently_ processing messages are stopped before we change the namespace.
+        // This ensures that any unprocessed messages are ignored and don't cause havoc by running while we try to 
+        // reset the application internal state.
+        applyToRoutesExceptTestControl(route -> context.getRouteController().suspendRoute(route.getRouteId()), true);
         this.currentNamespace = currentNamespace;
+        applyToRoutesExceptTestControl(route -> context.getRouteController().resumeRoute(route.getRouteId()), false);
+    }
+
+    private void applyToRoutesExceptTestControl(ThrowingConsumer<Route, Exception> routeConsumer, boolean reverseOrder) {
+        // This reproduces a bit of logic inside camel; but adding filtering so we can startup and shutdown 
+        // non-test-control routes only.
+        var comp = Comparator.comparingInt(RouteStartupOrder::getStartupOrder);
+        if (reverseOrder) {
+            comp = comp.reversed();
+        }
+        ((AbstractCamelContext)context).getRouteStartupOrder()
+                .stream()
+                .sorted(comp)
+                .map(RouteStartupOrder::getRoute)
+                .filter(route -> !route.getProperties().containsKey(AbstractTestControlCamelRouteBuilder.ROUTE_PROPERTY_IS_TEST_CONTROL))
+                .forEach(route -> {
+                    try {
+                        routeConsumer.accept(route);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
     }
 
     @Override


### PR DESCRIPTION
This is done in order to avoid processing messages during reset of
internal state , which can cause deadlocks on the database and therefore
test flakiness.

PHR-8722