### PR TITLE
PHR-10238 Add go implementation of test-control server.

### DIFF
--- a/.github/workflows/test-control-go.yml
+++ b/.github/workflows/test-control-go.yml
@@ -1,0 +1,28 @@
+name: 'Build and test test-control-go module'
+on:
+  workflow_dispatch:
+  pull_request:
+defaults:
+  run:
+    working-directory: test-control-go
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: "Setup Go"
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.18'
+      - name: "Build"
+        run: go build
+      - name: "Vet"
+        run: go vet
+      # Checks that all code is correctly formatted. Use test -z to check for empty output.
+      # https://github.com/golang/go/issues/24230
+      - name: "Check format"
+        run: test -z $(gofmt -l .)
+      # Runs unit tests
+      - name: "Test"
+        run: go test

--- a/test-control-go/README.md
+++ b/test-control-go/README.md
@@ -13,6 +13,7 @@ Example:
 package main
 
 import (
+        "context"
 	"github.com/patientsknowbest/pkb-common/test-control"
 	"log"
 )
@@ -24,6 +25,6 @@ type myTestControl struct{}
 ///
 
 func main() {
-	go log.Fatal(testcontrol.RunTestControl(":9876", "http://test-control:9876", "foo", "http://foo:9876", myTestControl{}))
+	go log.Fatal(testcontrol.RunTestControl(context.Background(), ":9876", "http://test-control:9876", "foo", "http://foo:9876", myTestControl{}))
 }
 ```

--- a/test-control-go/README.md
+++ b/test-control-go/README.md
@@ -1,0 +1,29 @@
+# test-control-client-go
+
+Test control server implementation for go applications developed by PKB.
+
+Application must provide an implementation of testcontrol.TestControl and call RunTestControl in a goroutine in order to 
+participate in test-control.
+
+java equivalent lives in [test-control](../test-control) folder, with message structures defined in [here](../test-control-client/src/main/java/com/pkb/common/testcontrol/message)
+
+Example:
+
+```go
+package main
+
+import (
+	"github.com/patientsknowbest/pkb-common/test-control"
+	"log"
+)
+
+type myTestControl struct{}
+
+/// Implement TestControl interface for myTestControl
+/// func SetNamespace...
+///
+
+func main() {
+	go log.Fatal(testcontrol.RunTestControl(":9876", "http://test-control:9876", "foo", "http://foo:9876", myTestControl{}))
+}
+```

--- a/test-control-go/go.mod
+++ b/test-control-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/patientsknowbest/pkb-common/test-control-go
+
+go 1.18

--- a/test-control-go/lib.go
+++ b/test-control-go/lib.go
@@ -53,6 +53,7 @@ func RunTestControl(
 	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"clearStorage", impl.handleClearStorage)
 	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"logTestName", impl.handleLogTestName)
 	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"toggleDetailedLogging", impl.handleToggleDetailedLogging)
+	sm.HandleFunc("/health", impl.handleHealth)
 	log.Printf("starting test-control API on %s", listenAddress)
 	svr := &http.Server{Addr: listenAddress, Handler: sm}
 	go func() {
@@ -168,6 +169,13 @@ func (t *testControlImpl) handleLogTestName(res http.ResponseWriter, req *http.R
 	handle(res, req, v, func(ctx context.Context, v *request) error {
 		return t.LogTestName(ctx, v.TestName)
 	})
+}
+
+func (t *testControlImpl) handleHealth(res http.ResponseWriter, req *http.Request) {
+	res.WriteHeader(http.StatusOK)
+	res.Write([]byte(`{
+  		"status": "pass",
+  	`))
 }
 
 func register(registrationEndpoint, myName, myCallbackUrl string) error {

--- a/test-control-go/lib.go
+++ b/test-control-go/lib.go
@@ -1,0 +1,185 @@
+package testcontrol
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// TestControl / applications should provide an implementation of this interface to participate in test-control.
+type TestControl interface {
+	SetNamespace(ctx context.Context, newNamespace string) error
+	InjectConfig(ctx context.Context, key string, value string) error
+	SetFixedTimestamp(ctx context.Context, timestamp string) error
+	MoveTime(ctx context.Context, amount int, unit string) error
+	ClearInternalState(ctx context.Context, clearFixedTimestamp bool) error
+	ClearStorage(ctx context.Context) error
+	LogTestName(ctx context.Context, testName string) error
+	ToggleDetailedLogging(ctx context.Context, enable bool) error
+}
+
+// RunTestControl / applications should call this to optionally register with the test-control server
+// and handle test-control requests.
+// listenAddress: the address this application will listen on for test-control requests
+// registrationEndpoint: the address of a test-control server to register with. If empty, we won't register.
+// myName, myCallbackUrl: application name and callback URL for the test-control server to call this application on.
+// control: implementation of TestControl interface, handling this applications state etc.
+// This function blocks forever.
+func RunTestControl(listenAddress, registrationEndpoint, myName, myCallbackUrl string, control TestControl) error {
+	if registrationEndpoint != "" {
+		err := register(registrationEndpoint, myName, myCallbackUrl)
+		if err != nil {
+			return err
+		}
+	}
+
+	impl := testControlImpl{control}
+	sm := http.NewServeMux()
+	IoPkbTestcontrolPrefix := "io-pkb-testcontrol-"
+	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"setNamespace", impl.handleSetNamespace)
+	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"injectConfig", impl.handleInjectConfig)
+	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"setFixedTimestamp", impl.handleSetFixedTimestamp)
+	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"moveTime", impl.handleMoveTime)
+	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"clearInternalState", impl.handleClearInternalState)
+
+	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"clearStorage", impl.handleClearStorage)
+	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"logTestName", impl.handleLogTestName)
+	sm.HandleFunc("/"+IoPkbTestcontrolPrefix+"toggleDetailedLogging", impl.handleToggleDetailedLogging)
+	log.Printf("starting test-control API on %s", listenAddress)
+	return http.ListenAndServe(listenAddress, sm)
+}
+
+type testControlImpl struct {
+	TestControl
+}
+
+func handle[T any](res http.ResponseWriter, req *http.Request, t T, f func(context.Context, T) error) {
+	log.Printf("handling test control request %s", req.URL.Path)
+	err := json.NewDecoder(req.Body).Decode(t)
+	if err != nil {
+		log.Println(err)
+		res.WriteHeader(http.StatusBadRequest)
+		_, _ = res.Write([]byte(err.Error()))
+		return
+	}
+	err = f(req.Context(), t)
+	if err != nil {
+		log.Println(err)
+		res.WriteHeader(http.StatusInternalServerError)
+		_, _ = res.Write([]byte(err.Error()))
+		return
+	}
+	res.WriteHeader(http.StatusNoContent)
+	log.Printf("handling test control request %s complete", req.URL.Path)
+}
+
+func (t *testControlImpl) handleSetNamespace(res http.ResponseWriter, req *http.Request) {
+	type setNamespaceReq struct {
+		NewNamespace string `json:"newNamespace"`
+	}
+	v := &setNamespaceReq{}
+	handle(res, req, v, func(ctx context.Context, v *setNamespaceReq) error {
+		return t.SetNamespace(req.Context(), v.NewNamespace)
+	})
+}
+
+func (t *testControlImpl) handleToggleDetailedLogging(res http.ResponseWriter, req *http.Request) {
+	type request struct {
+		EnableDetailedLogging bool `json:"enableDetailedLogging"`
+	}
+	v := &request{}
+	handle(res, req, v, func(ctx context.Context, v *request) error {
+		return t.ToggleDetailedLogging(ctx, v.EnableDetailedLogging)
+	})
+}
+
+func (t *testControlImpl) handleInjectConfig(res http.ResponseWriter, req *http.Request) {
+	type request struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+	v := &request{}
+	handle(res, req, v, func(ctx context.Context, v *request) error {
+		return t.InjectConfig(ctx, v.Key, v.Value)
+	})
+}
+
+func (t *testControlImpl) handleSetFixedTimestamp(res http.ResponseWriter, req *http.Request) {
+	type request struct {
+		Timestamp string `json:"timestamp"`
+	}
+	v := &request{}
+	handle(res, req, v, func(ctx context.Context, v *request) error {
+		return t.SetFixedTimestamp(ctx, v.Timestamp)
+	})
+}
+
+func (t *testControlImpl) handleMoveTime(res http.ResponseWriter, req *http.Request) {
+	type request struct {
+		Amount int    `json:"amount"`
+		Unit   string `json:"unit"`
+	}
+	v := &request{}
+	handle(res, req, v, func(ctx context.Context, v *request) error {
+		return t.MoveTime(ctx, v.Amount, v.Unit)
+	})
+}
+
+func (t *testControlImpl) handleClearInternalState(res http.ResponseWriter, req *http.Request) {
+	type request struct {
+		ClearFixedTimestamp bool `json:"clearFixedTimestamp"`
+	}
+	v := &request{}
+	handle(res, req, v, func(ctx context.Context, v *request) error {
+		return t.ClearInternalState(ctx, v.ClearFixedTimestamp)
+	})
+}
+
+func (t *testControlImpl) handleClearStorage(res http.ResponseWriter, req *http.Request) {
+	type request struct{}
+	v := &request{}
+	handle(res, req, v, func(ctx context.Context, v *request) error {
+		return t.ClearStorage(ctx)
+	})
+}
+
+func (t *testControlImpl) handleLogTestName(res http.ResponseWriter, req *http.Request) {
+	type request struct {
+		TestName string ``
+	}
+	v := &request{}
+	handle(res, req, v, func(ctx context.Context, v *request) error {
+		return t.LogTestName(ctx, v.TestName)
+	})
+}
+
+func register(registrationEndpoint, myName, myCallbackUrl string) error {
+	log.Printf("registering with test-control server %s name %s callback %s", registrationEndpoint, myName, myCallbackUrl)
+	startup := struct {
+		Name     string `json:"name"`
+		Callback string `json:"callback"`
+	}{
+		Name:     myName,
+		Callback: myCallbackUrl,
+	}
+	startMsg, err := json.Marshal(startup)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPut, registrationEndpoint, bytes.NewReader(startMsg))
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return fmt.Errorf("unexpected status code from registration %d %s", resp.StatusCode, resp.Status)
+	}
+	log.Printf("registered with test-control %v, %s", startup, registrationEndpoint)
+	return nil
+}

--- a/test-control-go/lib_test.go
+++ b/test-control-go/lib_test.go
@@ -1,0 +1,119 @@
+package testcontrol
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testTestControl struct {
+	didSetNamespace     bool
+	namespace           string
+	errorOnSetNamespace error
+}
+
+func (t *testTestControl) SetNamespace(ctx context.Context, newNamespace string) error {
+	t.didSetNamespace = true
+	t.namespace = newNamespace
+	return t.errorOnSetNamespace
+}
+func (t *testTestControl) InjectConfig(ctx context.Context, key string, value string) error {
+	return nil
+}
+func (t *testTestControl) SetFixedTimestamp(ctx context.Context, timestamp string) error {
+	return nil
+}
+func (t *testTestControl) MoveTime(ctx context.Context, amount int, unit string) error {
+	return nil
+}
+func (t *testTestControl) ClearInternalState(ctx context.Context, clearFixedTimestamp bool) error {
+	return nil
+}
+func (t *testTestControl) ClearStorage(ctx context.Context) error {
+	return nil
+}
+func (t *testTestControl) LogTestName(ctx context.Context, testName string) error {
+	return nil
+}
+func (t *testTestControl) ToggleDetailedLogging(ctx context.Context, enable bool) error {
+	return nil
+}
+
+func TestSetNamespace(t *testing.T) {
+	withTestControlServer(t, func(t *testing.T, testControlBaseUrl string, impl *testTestControl) {
+		request, err := http.NewRequest(http.MethodPut, testControlBaseUrl+"/io-pkb-testcontrol-setNamespace", strings.NewReader(`{"newNamespace": "fooNamespace"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		if response.StatusCode != http.StatusNoContent {
+			t.Fatalf("unexpected status %s", response.Status)
+		}
+
+		if !impl.didSetNamespace {
+			t.Errorf("expected didSetNamespace=true")
+		}
+		if impl.namespace != "fooNamespace" {
+			t.Errorf("expected namespace=fooNamespace")
+		}
+	})
+}
+
+func TestSetNamespaceError(t *testing.T) {
+	withTestControlServer(t, func(t *testing.T, testControlBaseUrl string, impl *testTestControl) {
+		impl.errorOnSetNamespace = fmt.Errorf("oh noes an error")
+		request, err := http.NewRequest(http.MethodPut, testControlBaseUrl+"/io-pkb-testcontrol-setNamespace", strings.NewReader(`{"newNamespace": "fooNamespace"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if response.StatusCode != http.StatusInternalServerError {
+			t.Errorf("unexpected status code %s", response.Status)
+		}
+	})
+}
+
+func withTestControlServer(t *testing.T, f func(*testing.T, string, *testTestControl)) {
+	// boot the test control server
+	serverContext, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testControlListenAddress := "127.0.0.1:9876"
+	testControlBaseUrl := "http://" + testControlListenAddress
+	impl := &testTestControl{}
+	go RunTestControl(serverContext, testControlListenAddress, "", "foo", "foo", impl)
+
+	// Wait for it to be healthy
+	healthUrl := testControlBaseUrl + "/health"
+	timeout := 2 * time.Second
+	cx2, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		request, err := http.NewRequestWithContext(cx2, http.MethodGet, healthUrl, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := http.DefaultClient.Do(request)
+		if err == nil && res.StatusCode == http.StatusOK {
+			break
+		}
+		select {
+		case <-cx2.Done():
+			t.Fatalf("failed to reach %s after %v", testControlBaseUrl, timeout)
+		case <-time.After(50 * time.Millisecond):
+			continue
+		}
+	}
+
+	// Run the test
+	f(t, testControlBaseUrl, impl)
+}


### PR DESCRIPTION
Extracted http server code from https://github.com/patientsknowbest/docker/tree/master/postgres-test-base/test-control

Defines a module which can be used in applications written in go so they can participate in test-control.