### PR TITLE
Upgrade dependencies due to OWASP check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,17 +53,17 @@
 
         <version.apache.commons.lang3>3.12.0</version.apache.commons.lang3>
         <version.jetbrain.annotations>19.0.0</version.jetbrain.annotations>
-        <version.guava>31.1-jre</version.guava>
+        <version.guava>32.1.2-jre</version.guava>
         <version.apache-commons-io>2.6</version.apache-commons-io>
         <javax.javaee-api.version>8.0</javax.javaee-api.version>
         <avro.version>1.11.0</avro.version>
-        <camel.version>3.20.2</camel.version>
+        <camel.version>3.20.6</camel.version>
 
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.flatten.plugin.version>1.2.7</maven.flatten.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
-        <owasp-dependency-check.version>6.4.1</owasp-dependency-check.version>
+        <owasp-dependency-check.version>8.4.0</owasp-dependency-check.version>
         <plugin.version.maven.enforcer>3.0.0</plugin.version.maven.enforcer>
         <plugin.version.maven.extra.enforcer.rules.version>1.4</plugin.version.maven.extra.enforcer.rules.version>
         <pitest.version>1.7.2</pitest.version>
@@ -75,14 +75,14 @@
 
         <commons.testing.version>54-8e2e575-247593</commons.testing.version>
         <spring-cloud.version>2021.0.5</spring-cloud.version>
-        <spring.boot.version>2.7.10</spring.boot.version>
+        <spring.boot.version>2.7.14</spring.boot.version>
         <immutables.version>2.9.0</immutables.version>
-        <checker-qual.version>3.32.0</checker-qual.version>
-        <kotlin.version>1.6.21</kotlin.version>
+        <checker-qual.version>3.37.0</checker-qual.version>
+        <kotlin.version>1.9.0</kotlin.version>
         <errorprone.version>2.18.0</errorprone.version>
         <groovy.version>2.5.17</groovy.version>
         <retrofit.version>2.9.0</retrofit.version>
-        <okhttp.version>4.10.0</okhttp.version>
+        <okhttp.version>4.11.0</okhttp.version>
         <jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <hibernate-core.version>5.6.15.Final</hibernate-core.version> <!-- Please ensure that this remains consistent with the version specified in the spring boot bom -->
@@ -97,8 +97,14 @@
         <spring-cloud-gcp.version>3.4.7</spring-cloud-gcp.version>
 
 
-        <jackson-bom.version>2.14.2</jackson-bom.version>
+        <jackson-bom.version>2.15.2</jackson-bom.version>
         <google.gson.version>2.10.1</google.gson.version>
+
+        <google-cloud-bom-version>26.17.0</google-cloud-bom-version>
+        <grpc.version>1.57.2</grpc.version>
+        <j2objc-annotations.version>2.8</j2objc-annotations.version>
+
+        <okio.version>3.5.0</okio.version> <!-- Pinning version to avoid issue with 3.2.0 (from okhttp) -->
     </properties>
 
     <modules>
@@ -117,6 +123,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>spring-cloud-gcp-dependencies</artifactId>
@@ -360,6 +373,18 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk7</artifactId>
+                <version>${kotlin.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${kotlin.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
                 <version>${errorprone.version}</version>
@@ -403,6 +428,16 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${google.gson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.j2objc</groupId>
+                <artifactId>j2objc-annotations</artifactId>
+                <version>${j2objc-annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -494,6 +529,7 @@
                 <configuration>
                     <skipProvidedScope>true</skipProvidedScope>
                     <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+                    <knownExploitedEnabled>false</knownExploitedEnabled>
                     <excludes>
                         <exclude>org.springframework</exclude>
                     </excludes>

--- a/suppression.xml
+++ b/suppression.xml
@@ -19,14 +19,24 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-.*$</packageUrl>
         <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
     </suppress>
-    <suppress until="2023-06-01Z">
-        <!-- Refer to https://github.com/google/guava/issues/4011 -->
-        <!-- Hopefully Google will either remove or update the deprecated method that is affected by this CVE; until then we suppress it -->
+    <suppress>
+        <!-- Please refer to https://github.com/FasterXML/jackson-databind/issues/3972 -->
+        <!-- According to the issue discussion this should not be considered a CVE hence the suppression -->
         <notes><![CDATA[
-   file name: guava-31.1-jre.jar
+   file name: jackson-databind-2.15.2.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+        <cve>CVE-2023-35116</cve>
+    </suppress>
+    <suppress>
+        <!-- [CVE-2020-8908] - The problem is not fixed but the method that is causing it is deprecated -->
+        <!-- [CVE-2023-2976] - The issue mentions a problem in Guava version up to 32 (exclusive) and we are now at 32.1.2 -->
+        <notes><![CDATA[
+   file name: auto-value-1.10.1.jar (shaded: com.google.guava:guava:31.1-jre)
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
         <cve>CVE-2020-8908</cve>
+        <cve>CVE-2023-2976</cve>
     </suppress>
 
 </suppressions>


### PR DESCRIPTION
**Rationale:**
It had been a while since we had upgraded versions in `pkb-common`. In `phr` one of the latest issues raised by the OWASP dependency checker revealed one problem in a transitive library used here. This PR upgrades the dependency checker as well as a lot of dependencies with old versions.
We have also added a couple of suppressions.