### PR TITLE
PHR-11742 Add new AgeUtilService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <module>spring-boot-infrastructure</module>
         <module>spring-boot-kotlin-infrastructure</module>
         <module>pubsub</module>
+	<module>util</module>
     </modules>
 
     <dependencyManagement>

--- a/suppression.xml
+++ b/suppression.xml
@@ -38,5 +38,14 @@
         <cve>CVE-2020-8908</cve>
         <cve>CVE-2023-2976</cve>
     </suppress>
-
+    <suppress until="2023-11-01">
+        <notes><![CDATA[
+   file name: netty-handler-4.1.94.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+        <!-- This is not a vulnerability, just the fact that it's possible to misconfigure and disable hostname verification -->
+        <!-- see https://github.com/netty/netty/issues/8537 and https://github.com/netty/netty/issues/9930 -->
+        <!-- It's very possible that this won't ever go away, just increase the suppression then -->
+        <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>pkb-common</artifactId>
+        <groupId>com.pkb.pkbcommon</groupId>
+        <version>${revision}${changelist}</version>
+    </parent>
+
+    <artifactId>util</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.pkb.pkbcommon</groupId>
+            <artifactId>date-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest-junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/util/src/main/java/com/pkb/pkbcommon/ageutil/AgeUtilService.java
+++ b/util/src/main/java/com/pkb/pkbcommon/ageutil/AgeUtilService.java
@@ -1,0 +1,25 @@
+package com.pkb.pkbcommon.ageutil;
+
+import com.pkb.common.datetime.DateTimeService;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+public class AgeUtilService {
+
+    private final DateTimeService dateTimeService;
+
+    public AgeUtilService(DateTimeService dateTimeService) {
+        this.dateTimeService = dateTimeService;
+    }
+
+    public final static int MINIMUM_AGE_LETTER_INVITATION = 16;
+
+    public boolean patientIsOlderThan(LocalDate dateOfBirth, int ageInYears) {
+        return dateOfBirth.plus(ageInYears, ChronoUnit.YEARS)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant()
+                .isBefore(dateTimeService.now());
+    }
+}

--- a/util/src/main/java/com/pkb/pkbcommon/ageutil/AgeUtilService.java
+++ b/util/src/main/java/com/pkb/pkbcommon/ageutil/AgeUtilService.java
@@ -14,8 +14,6 @@ public class AgeUtilService {
         this.dateTimeService = dateTimeService;
     }
 
-    public final static int MINIMUM_AGE_LETTER_INVITATION = 16;
-
     public boolean patientIsOlderThan(LocalDate dateOfBirth, int ageInYears) {
         return dateOfBirth.plus(ageInYears, ChronoUnit.YEARS)
                 .atStartOfDay(ZoneOffset.UTC)

--- a/util/src/test/java/com/pkb/pkbcommon/ageutil/AgeUtilServiceTest.java
+++ b/util/src/test/java/com/pkb/pkbcommon/ageutil/AgeUtilServiceTest.java
@@ -9,10 +9,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 
 import static com.github.karsaig.approvalcrest.jupiter.MatcherAssert.assertThat;
-import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
@@ -28,16 +26,15 @@ public class AgeUtilServiceTest {
     public void testUnderSixteen() {
         Instant currentTime = Instant.parse("2020-01-02T00:00:00Z");
         when(dateTimeService.now()).thenReturn(currentTime);
-        LocalDate dateOfBirth = currentTime.atZone(UTC).minus(16, ChronoUnit.YEARS).toLocalDate();
+        LocalDate dateOfBirth = LocalDate.of(2004,1,2);
         assertThat(underTest.patientIsOlderThan(dateOfBirth, 16), is(false));
     }
 
     @Test
-    public void testOverSixteen() {
-        Instant currentTime = Instant.parse("2020-01-02T00:00:00Z");
+    public void testOverSixteenByOneSecond() {
+        Instant currentTime = Instant.parse("2020-01-02T00:01:00Z");
         when(dateTimeService.now()).thenReturn(currentTime);
-        LocalDate dateOfBirth = currentTime.atZone(UTC).minus(16, ChronoUnit.YEARS).minus(1, ChronoUnit.DAYS).toLocalDate();
+        LocalDate dateOfBirth = LocalDate.of(2004,1,2);
         assertThat(underTest.patientIsOlderThan(dateOfBirth, 16), is(true));
     }
-
 }

--- a/util/src/test/java/com/pkb/pkbcommon/ageutil/AgeUtilServiceTest.java
+++ b/util/src/test/java/com/pkb/pkbcommon/ageutil/AgeUtilServiceTest.java
@@ -1,0 +1,43 @@
+package com.pkb.pkbcommon.ageutil;
+
+import com.pkb.common.datetime.DateTimeService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import static com.github.karsaig.approvalcrest.jupiter.MatcherAssert.assertThat;
+import static java.time.ZoneOffset.UTC;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AgeUtilServiceTest {
+
+    @Mock
+    DateTimeService dateTimeService;
+    @InjectMocks
+    AgeUtilService underTest;
+
+    @Test
+    public void testUnderSixteen() {
+        Instant currentTime = Instant.parse("2020-01-02T00:00:00Z");
+        when(dateTimeService.now()).thenReturn(currentTime);
+        LocalDate dateOfBirth = currentTime.atZone(UTC).minus(16, ChronoUnit.YEARS).toLocalDate();
+        assertThat(underTest.patientIsOlderThan(dateOfBirth, 16), is(false));
+    }
+
+    @Test
+    public void testOverSixteen() {
+        Instant currentTime = Instant.parse("2020-01-02T00:00:00Z");
+        when(dateTimeService.now()).thenReturn(currentTime);
+        LocalDate dateOfBirth = currentTime.atZone(UTC).minus(16, ChronoUnit.YEARS).minus(1, ChronoUnit.DAYS).toLocalDate();
+        assertThat(underTest.patientIsOlderThan(dateOfBirth, 16), is(true));
+    }
+
+}


### PR DESCRIPTION
This adds a service which contains code which is used by ConsentService, LetterInvitationValidator and LetterInvitationValidatorService, to avoid duplicating the code across these three places.

This is part of a larger change to prevent invitation letters being sent out to under-16s

The jira is here: https://pkbdev.atlassian.net/browse/PHR-11742 
and the corresponding PHR PR which makes use of this service is here: https://github.com/patientsknowbest/phr/pull/7493